### PR TITLE
[20210425]docker環境を追加

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: "3.8"
+
+volumes:
+    php_sockert:
+
+services:
+  web:
+    build:
+      context: src
+      dockerfile: web.Dockerfile
+    container_name: web
+    volumes:
+      - php_sockert:/var/run/php-fpm
+    ports:
+    - "8080:80"
+    depends_on:
+      - app
+
+  app:
+    build:
+      context: src
+      dockerfile: app.Dockerfile
+    container_name: app
+    volumes:
+      - ./src:/var/www
+      - php_sockert:/var/run/php-fpm
+    depends_on:
+      - db
+
+  db:
+    build:
+      context: src
+      dockerfile: db.Dockerfile
+    container_name: db
+    ports:
+      - "3306:3306"

--- a/src/app.Dockerfile
+++ b/src/app.Dockerfile
@@ -1,0 +1,28 @@
+FROM php:8.0-fpm-alpine
+
+# composer
+COPY --from=composer:2.0 /usr/bin/composer /usr/bin/composer
+
+# package install
+RUN set -eux && \
+    apk update && \
+    apk add --update --no-cache \
+    autoconf \
+    gcc \
+    g++ \
+    git \
+    icu-dev \
+    libzip-dev \
+    make \
+    oniguruma-dev \
+    unzip  && \
+    docker-php-ext-install intl pdo_mysql zip bcmath
+
+# copy setting & sources file
+COPY docker/app/php.ini /usr/local/etc/php/php.ini
+COPY docker/app/zzz-docker.conf /usr/local/etc/php-fpm.d/zzz-docker.conf
+COPY ./ /var/www
+
+# unix socket
+RUN mkdir /var/run/php-fpm
+VOLUME ["/var/run/php-fpm"]

--- a/src/db.Dockerfile
+++ b/src/db.Dockerfile
@@ -1,0 +1,10 @@
+FROM mysql:8.0
+
+ENV MYSQL_DATABASE=local \
+    MYSQL_USER=test \
+    MYSQL_PASSWORD=secret \
+    MYSQL_ROOT_PASSWORD=secret \
+    TZ=Asia/Tokyo
+
+COPY docker/db/my.cnf /etc/mysql/conf.d/my.cnf
+RUN chmod 644 /etc/mysql/conf.d/my.cnf

--- a/src/docker/app/php.ini
+++ b/src/docker/app/php.ini
@@ -1,0 +1,25 @@
+zend.exception_ignore_args = off
+expose_php = on
+max_execution_time = 30
+max_input_vars = 1000
+upload_max_filesize = 64M
+post_max_size = 128M
+memory_limit = 256M
+error_reporting = E_ALL
+display_errors = on
+display_startup_errors = on
+log_errors = on
+error_log = /dev/stderr
+default_charset = UTF-8
+
+[Date]
+date.timezone = Asia/Tokyo
+
+[mysqlnd]
+mysqlnd.collect_memory_statistics = on
+
+[Assertion]
+zend.assertions = 1
+
+[mbstring]
+mbstring.language = Japanese

--- a/src/docker/app/zzz-docker.conf
+++ b/src/docker/app/zzz-docker.conf
@@ -1,0 +1,11 @@
+[global]
+daemonize = no
+
+[www]
+user  = www-data
+group = www-data
+
+listen = /var/run/php-fpm/php-fpm.sock
+listen.owner = www-data
+listen.group = www-data
+listen.mode = 0666

--- a/src/docker/db/my.cnf
+++ b/src/docker/db/my.cnf
@@ -1,0 +1,27 @@
+[mysqld]
+# character set / collation
+character_set_server = utf8mb4
+collation_server = utf8mb4_0900_ai_ci
+
+# timezone
+default-time-zone = SYSTEM
+log_timestamps = SYSTEM
+
+# Error Log
+log-error = mysql-error.log
+
+# Slow Query Log
+slow_query_log = 1
+slow_query_log_file = mysql-slow.log
+long_query_time = 1.0
+log_queries_not_using_indexes = 0
+
+# General Log
+general_log = 1
+general_log_file = mysql-general.log
+
+[mysql]
+default-character-set = utf8mb4
+
+[client]
+default-character-set = utf8mb4

--- a/src/docker/web/default.conf
+++ b/src/docker/web/default.conf
@@ -1,0 +1,47 @@
+user  www-data;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    server {
+        listen 80;
+        root /var/www/public;
+        index index.php;
+        charset utf-8;
+
+        location / {
+            root /var/www/public;
+            index index.php;
+            try_files $uri $uri/ /index.php$is_args$args;
+        }
+
+        location ~ \.php$ {
+            fastcgi_split_path_info ^(.+\.php)(/.+)$;
+            fastcgi_pass unix:/var/run/php-fpm/php-fpm.sock;
+            fastcgi_index index.php;
+            include fastcgi_params;
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            fastcgi_param PATH_INFO $fastcgi_path_info;
+        }
+    }
+
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+    sendfile        on;
+    #tcp_nopush     on;
+    keepalive_timeout  65;
+    #gzip  on;
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/src/public/index.php
+++ b/src/public/index.php
@@ -1,0 +1,1 @@
+<?php phpinfo(); ?>

--- a/src/web.Dockerfile
+++ b/src/web.Dockerfile
@@ -6,7 +6,3 @@ RUN adduser -S www-data -G www-data -u 82 && \
     echo 'www-data:www-data' | chpasswd
 
 COPY docker/web/default.conf /etc/nginx/nginx.conf
-
-# unix socket
-RUN mkdir /var/run/php-fpm
-VOLUME ["/var/run/php-fpm"]

--- a/src/web.Dockerfile
+++ b/src/web.Dockerfile
@@ -1,0 +1,12 @@
+FROM nginx:1.19.6-alpine
+
+# unixソケット用のユーザを追加
+RUN adduser -S www-data -G www-data -u 82 && \
+    echo "www-data ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
+    echo 'www-data:www-data' | chpasswd
+
+COPY docker/web/default.conf /etc/nginx/nginx.conf
+
+# unix socket
+RUN mkdir /var/run/php-fpm
+VOLUME ["/var/run/php-fpm"]


### PR DESCRIPTION
## 参考情報

- [docker で nginx ＆ php-fpm の PHP 実行環境を構築する（TCP/UNIX domain socket](https://www.ritolab.com/entry/220)
- [docker-composeでunixソケットを使った、Nginx、php-fpmコンテナを作る](https://qiita.com/yCroma/items/c22d948b4393fbc96f53)